### PR TITLE
feat(kochosei_card): simplify health modification logic using percent…

### DIFF
--- a/scripts/prefabs/kochosei_card.lua
+++ b/scripts/prefabs/kochosei_card.lua
@@ -67,9 +67,9 @@ local function make(code, description, check_des_boolean, alter_description, fil
 					end
 				end
 				if code == "kochosei_card_health" then
+					local healthPercent = owner.components.health:GetPercent()
 					owner.components.health:SetMaxHealth(currentMaxHealth + 500)
-					owner.components.health:SetCurrentHealth(currentMaxHealth - DeltaHealth + 500)
-					owner.components.health:DoDelta(0.01)
+					owner.components.health:SetPercent(healthPercent)
 				end
 				owner:ListenForEvent("ms_respawnedfromghost", onbecamehuman)
 				--owner:DoTaskInTime(0, function()
@@ -101,17 +101,9 @@ local function make(code, description, check_des_boolean, alter_description, fil
 					end
 				end
 				if code == "kochosei_card_health" then
+					local healthPercent = owner.components.health:GetPercent()
 					owner.components.health:SetMaxHealth(currentMaxHealth - 500)
-					owner.components.health:DoDelta(DeltaHealth)
-					-- Cố tình gỡ thì thấp hơn 500 máu thì cút
-					--if (currentMaxHealth - DeltaHealth - 500) > 0 then
-					--    owner.components.health:SetCurrentHealth(currentMaxHealth - DeltaHealth - 500)
-					--    owner.components.health:DoDelta(-0.01)
-					--else
-					--    owner.components.health:SetCurrentHealth(1)
-					--    owner.components.health:DoDelta(-0.01)
-					--DoDelta để lấy hiệu ứng trên thanh máu
-					--end
+					owner.components.health:SetPercent(healthPercent)
 				end
 
 				owner:RemoveEventCallback("ms_respawnedfromghost", onbecamehuman)


### PR DESCRIPTION
…age-based approach

Replace complex health calculation with percentage-based health preservation when equipping/unequipping the health card. This ensures the player's health ratio remains consistent when max health changes by ±500.

- Store health percentage before modifying max health
- Restore percentage after max health change instead of manual calculations
- Remove commented-out legacy code and unnecessary DoDelta calls